### PR TITLE
Changes to databag name generation

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,0 +1,3 @@
+
+node['slurm-wlm']['configs']['ClusterName'] = 'cluster'
+

--- a/metadata.rb
+++ b/metadata.rb
@@ -55,5 +55,5 @@ attribute 'slurm-wlm/configs/ClusterName',
         'being configured. This value will be put in for ' \
         'the `ClusterName` parameter in `slurm.conf`',
     required: 'required',
-    default: 'slurm-wlm'
+    default: 'cluster'
 

--- a/recipes/conf.rb
+++ b/recipes/conf.rb
@@ -5,8 +5,14 @@
 # Copyright (c) 2016 The Authors, All Rights Reserved.
 
 # grab the data from data_bags
-nodes = data_bag_item('slurm-gizmo', 'nodes')
-partitions = data_bag_item('slurm-gizmo', 'partitions')
+nodes = data_bag_item(
+    "slurm-#{node['slurm-wlm']['configs']['ClusterName']}",
+    'nodes'
+)
+partitions = data_bag_item(
+    "slurm-#{node['slurm-wlm']['configs']['ClusterName']}",
+    'partitions'
+)
 
 # create the template and pass the data into the template
 template '/home/vagrant/slurm.conf' do


### PR DESCRIPTION
> Added code to generate databag name using root ("slurm-") and the value
> of the ClusterName parameter

@ericmaxwell how does this look to you- the databag will be named "slurm-<clustername>" so we'd set ClusterName to "gizmo" and create databag "slurm-gizmo".  Do you see this breaking anything you've done?
